### PR TITLE
Update Feline Ferocity to include missing card

### DIFF
--- a/Mage.Client/release/sample-decks/Commander/Commander 2017/FelineFerocity.dck
+++ b/Mage.Client/release/sample-decks/Commander/Commander 2017/FelineFerocity.dck
@@ -66,6 +66,7 @@
 1 [C17:158] Soul's Majesty
 1 [C17:73] Spirit of the Hearth
 1 [C17:224] Staff of Nin
+1 [C17:7] Stalking Leonin
 1 [C17:281] Stirring Wildwood
 1 [C17:75] Sunspear Shikari
 1 [C17:226] Swiftfoot Boots


### PR DESCRIPTION
Added missing "Stalking Leonin" that was implemented after deck was built.